### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###React Pirate Rrrr(React, Reflux & React-Router)
+### React Pirate Rrrr(React, Reflux & React-Router)
 
 ### What is React Pirate
 React Pirate is a boilerplate/starter kit for React/Flux Single Page Apps.  It provides a starting point that follows conventions and best practices recommended by production applications.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
